### PR TITLE
Adding an Animated 3D Model

### DIFF
--- a/components/scenes/ImportedAnimationScene.tsx
+++ b/components/scenes/ImportedAnimationScene.tsx
@@ -1,0 +1,71 @@
+// @ts-nocheck
+import React, { useRef, useEffect } from 'react'
+import { useGLTF, useAnimations } from '@react-three/drei'
+
+export default function Model(props) {
+  const group = useRef()
+  const { nodes, materials, animations } = useGLTF('/models/salsa.gltf')
+  const { actions } = useAnimations(animations, group)
+  useEffect(() => {
+    // console.log(actions)
+    actions.SalsaDancer.play()
+  })
+  return (
+    <group ref={group} {...props} dispose={null}>
+      <group
+        name='Armature'
+        rotation={[Math.PI / 2, 0, 0]}
+        scale={[0.01, 0.01, 0.01]}
+      >
+        <primitive object={nodes.Hips} />
+        <skinnedMesh
+          geometry={nodes.MocapGuy_Body_1.geometry}
+          material={nodes.MocapGuy_Body_1.material}
+          skeleton={nodes.MocapGuy_Body_1.skeleton}
+        />
+        <skinnedMesh
+          geometry={nodes.MocapGuy_Body_2.geometry}
+          material={materials['Reflectors.001']}
+          skeleton={nodes.MocapGuy_Body_2.skeleton}
+        />
+        <skinnedMesh
+          geometry={nodes.MocapGuy_BrowsLashes.geometry}
+          material={materials.Brows_MAT}
+          skeleton={nodes.MocapGuy_BrowsLashes.skeleton}
+        />
+        <skinnedMesh
+          geometry={nodes.MocapGuy_Caruncula.geometry}
+          material={nodes.MocapGuy_Caruncula.material}
+          skeleton={nodes.MocapGuy_Caruncula.skeleton}
+        />
+        <skinnedMesh
+          geometry={nodes.MocapGuy_Eyes.geometry}
+          material={materials.Eye_MAT}
+          skeleton={nodes.MocapGuy_Eyes.skeleton}
+        />
+        <skinnedMesh
+          geometry={nodes.MocapGuy_EyesSpec.geometry}
+          material={materials.Eye_Spec_MAT}
+          skeleton={nodes.MocapGuy_EyesSpec.skeleton}
+        />
+        <skinnedMesh
+          geometry={nodes.MocapGuy_Hat_1.geometry}
+          material={nodes.MocapGuy_Hat_1.material}
+          skeleton={nodes.MocapGuy_Hat_1.skeleton}
+        />
+        <skinnedMesh
+          geometry={nodes.MocapGuy_Hat_2.geometry}
+          material={materials.Reflectors}
+          skeleton={nodes.MocapGuy_Hat_2.skeleton}
+        />
+        <skinnedMesh
+          geometry={nodes.MocapGuy_Teeth.geometry}
+          material={nodes.MocapGuy_Teeth.material}
+          skeleton={nodes.MocapGuy_Teeth.skeleton}
+        />
+      </group>
+    </group>
+  )
+}
+
+useGLTF.preload('/models/salsa.gltf')

--- a/pages/api/rooms/roomData.json
+++ b/pages/api/rooms/roomData.json
@@ -20,9 +20,9 @@
     "link": "/imported-3d-object"
   },
   {
-    "title": "❌ Imported Animation",
-    "description": "This scene is currently in development. As soon as it's done, you'll see it here.",
-    "isNotDone": true
+    "title": "✅ Imported Animation",
+    "description": "A scene with an imported and converted FBX model that includes textures and animations.",
+    "link": "/imported-animation"
   },
   {
     "title": "❌  Dynamic Scene Loading",

--- a/pages/imported-animation/index.tsx
+++ b/pages/imported-animation/index.tsx
@@ -1,0 +1,45 @@
+import { Suspense } from 'react'
+import { OrbitControls, Stats, useAnimations } from '@react-three/drei'
+import { Canvas } from '@react-three/fiber'
+import BackHomeButton from '../../components/atoms/BackHomeButton'
+import dynamic from 'next/dynamic'
+import { Sky } from '@react-three/drei'
+
+const SalsaCharacter = dynamic(
+  () => import('../../components/scenes/ImportedAnimationScene'),
+  {
+    ssr: false
+  }
+)
+
+function Plane() {
+  return (
+    <mesh rotation={[-Math.PI / 2, 0, 0]}>
+      <planeBufferGeometry attach='geometry' args={[1000, 1000]} />
+      <meshBasicMaterial attach='material' color='darkgrey' />
+    </mesh>
+  )
+}
+
+export default function ImportedAnimation() {
+  return (
+    <div className='h-screen'>
+      <BackHomeButton />
+      <Canvas camera={{ position: [0, 1.25, 3] }} className='bg-black'>
+        <Plane />
+        <ambientLight intensity={0.6} />
+        <Suspense fallback={null}>
+          <SalsaCharacter />
+          <Sky
+            distance={450000}
+            sunPosition={[0, 1, 0]}
+            inclination={0}
+            azimuth={0.25}
+          />
+        </Suspense>
+        <OrbitControls />
+        <Stats />
+      </Canvas>
+    </div>
+  )
+}


### PR DESCRIPTION
# Animations, Here we go

<img width="1199" alt="animation" src="https://user-images.githubusercontent.com/34251194/119383977-51633480-bcc4-11eb-9ded-4de690c9a8ac.png">

## What

I added an animated 3D model of a motion capture guy dancing Salsa. 🕺🏻

## Why

To test if we can import ``.FBX`` files with textures, rigs/joints and animation keyframes.

## How

The model, inclusive textures and animations were downloaded from [Mixamo](https://www.mixamo.com). First, I downloaded it as a ``.FBX`` file and converted it to an ``.GLTF`` in Blender. Then, I used this article as guidance: <https://codeworkshop.dev/blog/2021-01-20-react-three-fiber-character-animation>.

Afterwards I used the [gltfjsx](https://github.com/pmndrs/gltfjsx) package to automatically turn the ``.GLTF`` file into a ``react-three-fiber`` component. Importing the component works like importing a normal 3D model (see the PR before <https://github.com/danburonline/oscy-space/pull/14>).
