### PR TITLE
Fixing the Bug That the Player was Slowly Sliding Down a Mesh

### DIFF
--- a/components/objects/complex/AdjustedPlayer.tsx
+++ b/components/objects/complex/AdjustedPlayer.tsx
@@ -7,60 +7,61 @@ type playerProps = {
   position?: number[]
 }
 
-const SPEED = 3
-const keys = {
-  KeyW: 'forward',
-  KeyS: 'backward',
-  KeyA: 'left',
-  KeyD: 'right',
-  Space: 'jump'
-}
-const moveFieldByKey = key => keys[key]
-const direction = new THREE.Vector3()
-const frontVector = new THREE.Vector3()
-const sideVector = new THREE.Vector3()
-
-const usePlayerControls = () => {
-  const [movement, setMovement] = useState({
-    forward: false,
-    backward: false,
-    left: false,
-    right: false
-  })
-  useEffect(() => {
-    // Init the event listener to the document at the first page render
-    const handleKeyDown = e => {
-      // api.allowSleep.set(false)
-      setMovement(m => ({ ...m, [moveFieldByKey(e.code)]: true }))
-    }
-
-    const handleKeyUp = e => {
-      // api.allowSleep.set(true)
-      setMovement(m => ({ ...m, [moveFieldByKey(e.code)]: false }))
-    }
-
-    document.addEventListener('keydown', handleKeyDown)
-    document.addEventListener('keyup', handleKeyUp)
-    return () => {
-      // Clean/Remove the event listener after the user exits the page
-      document.removeEventListener('keydown', handleKeyDown)
-      document.removeEventListener('keyup', handleKeyUp)
-    }
-  }, [])
-  return movement
-}
-
 export const Player = (props: playerProps) => {
   const [ref, api] = useSphere(() => ({
     args: 1,
-    mass: 10,
+    mass: 1,
     type: 'Dynamic',
-    // sleepSpeedLimit: 4,
+    sleepSpeedLimit: 4,
     // sleepTimeLimit: 4,
-    // sleepTimeLimit: 5,
-    allowSleep: false,
+    sleepTimeLimit: 0,
+    allowSleep: true,
     position: props.position || [10, 0, 0] // Default player position
   }))
+
+  const SPEED = 5
+  const keys = {
+    KeyW: 'forward',
+    KeyS: 'backward',
+    KeyA: 'left',
+    KeyD: 'right',
+    Space: 'jump'
+  }
+  const moveFieldByKey = key => keys[key]
+  const direction = new THREE.Vector3()
+  const frontVector = new THREE.Vector3()
+  const sideVector = new THREE.Vector3()
+
+  const usePlayerControls = () => {
+    const [movement, setMovement] = useState({
+      forward: false,
+      backward: false,
+      left: false,
+      right: false
+    })
+    useEffect(() => {
+      // Init the event listener to the document at the first page render
+      const handleKeyDown = e => {
+        // api.allowSleep.set(false)
+        setMovement(m => ({ ...m, [moveFieldByKey(e.code)]: true }))
+        api.applyForce([0.5, 0.5, 0.5], [0, 0, 0])
+      }
+
+      const handleKeyUp = e => {
+        // api.allowSleep.set(true)
+        setMovement(m => ({ ...m, [moveFieldByKey(e.code)]: false }))
+      }
+
+      document.addEventListener('keydown', handleKeyDown)
+      document.addEventListener('keyup', handleKeyUp)
+      return () => {
+        // Clean/Remove the event listener after the user exits the page
+        document.removeEventListener('keydown', handleKeyDown)
+        document.removeEventListener('keyup', handleKeyUp)
+      }
+    }, [])
+    return movement
+  }
 
   const { forward, backward, left, right } = usePlayerControls()
   const { camera } = useThree()

--- a/components/scenes/ForestMeshCollider.tsx
+++ b/components/scenes/ForestMeshCollider.tsx
@@ -113,7 +113,6 @@ export default function ForestMeshCollider() {
             <ForestGround />
             <ForestFoliage />
             <Player position={[0, 1, 0]} />
-            {/* <Ground /> */}
           </Physics>
         </Suspense>
         <PointerLockControls />

--- a/components/scenes/LightMapScene.tsx
+++ b/components/scenes/LightMapScene.tsx
@@ -172,7 +172,7 @@ export default function ForestMeshCollider() {
     <>
       <Canvas className='bg-black' camera={{ position: [0, 1, 5] }}>
         <Suspense fallback={null}>
-          <Physics gravity={[0, -30, 0]}>
+          <Physics gravity={[0, -30, 0]} allowSleep={true}>
             <ForestGround />
             <ForestFoliageWithTexture />
             <Player position={[0, 1, 0]} />


### PR DESCRIPTION


https://user-images.githubusercontent.com/34251194/123654751-abf53080-d82e-11eb-861b-15f6e60997a7.mov



Before this PR, the player slowly slid down a mesh when there was no perfectly straight ground/collision mesh beneath it. Now, this doesn't happen anymore.

The reason; I added a sleepSpeed and sleepTime limit to stop the player after not having enough speed/velocity.

```tsx
export const Player = (props: playerProps) => {
  const [ref, api] = useSphere(() => ({
    args: 1,
    mass: 1,
    type: 'Dynamic',
    sleepSpeedLimit: 4,
    sleepTimeLimit: 0,
    allowSleep: true,
    position: props.position || [10, 0, 0] // Default player position
  }))
// ...
```

And to re-awake the physics body (the sphere around the player) we simply do it by adding an applied force to the keyboard event listener:

```tsx
  const usePlayerControls = () => {
    const [movement, setMovement] = useState({
      forward: false,
      backward: false,
      left: false,
      right: false
    })
    useEffect(() => {
      const handleKeyDown = e => {
        setMovement(m => ({ ...m, [moveFieldByKey(e.code)]: true }))
        api.applyForce([0.5, 0.5, 0.5], [0, 0, 0])
      }
// ...
```

That's it 🎊 